### PR TITLE
[TASK] update release notes link

### DIFF
--- a/template.html
+++ b/template.html
@@ -50,7 +50,7 @@ try {
         <div class="a" id="aside">
             <ul id="nav-aside">
                 <li class="nav-aside-lvl1">
-                    <a href="https://typo3.org/download/release-notes/typo3-62-release-notes/" target="_top"
+                    <a href="https://typo3.org/index.php?id=316" target="_top"
                        title="Release Notes"
                        class="nav-aside-lvl1">Release Notes
                     </a>


### PR DESCRIPTION
I've changed the URL of the Release Notes to the parent page which is of type "shortcut" to first subpage. This will help to keep the link working even for future TYPO3 versions.
